### PR TITLE
Update outdated codes

### DIFF
--- a/custom_components/kincony-sha/light.py
+++ b/custom_components/kincony-sha/light.py
@@ -66,7 +66,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 	add_entities(lights)
 
 
-class CommandLight(Light):
+class CommandLight(SwitchEntity):
 	def __init__(
 		self,
 		hass,

--- a/custom_components/kincony-sha/light.py
+++ b/custom_components/kincony-sha/light.py
@@ -5,7 +5,7 @@ import subprocess
 import voluptuous as vol
 
 from homeassistant.components.light import (
-	Light,
+	LightEntity,
 	ENTITY_ID_FORMAT,
 	PLATFORM_SCHEMA,
 )

--- a/custom_components/kincony-sha/switch.py
+++ b/custom_components/kincony-sha/switch.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant.components.switch import (
 	ENTITY_ID_FORMAT,
 	PLATFORM_SCHEMA,
-	SwitchDevice,
+	SwitchEntity,
 )
 from homeassistant.const import (
 	CONF_FRIENDLY_NAME,

--- a/custom_components/kincony-sha/switch.py
+++ b/custom_components/kincony-sha/switch.py
@@ -67,7 +67,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 	add_entities(switches)
 
 
-class CommandSwitch(SwitchDevice):
+class CommandSwitch(SwitchEntity):
 	"""Representation a switch that can be toggled using shell commands."""
 
 	def __init__(


### PR DESCRIPTION
This change will make this extension work with the latest Home Assistant version 2022.9.1 (tested).

The new version of Home Assistant has changed the names of the Light and Switch classes.

See more: https://github.com/home-assistant/developers.home-assistant/blob/693797f3c23baddcfed2817a1501cdf0561355f7/blog/2020-05-14-entity-class-names.md

Note: This modification changes the outdated class names, so this extension will no longer work on old versions of Home Assistant!

